### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Ricardo Moreno
 maintainer=Ricardo Moreno <rmorenojr@live.com>
 sentence=Alarm Clock library for a the ZS-042 module, which has a DS3231 rtc and AT24C32N EEprom.
 paragraph= A Simple Alarm Clock library that uses the real time clock of a common ZS-042 module, aka. DS3231, with a AT24C32N EEprom and CR3032 battery.
-category=rtc
+category=Timing
 url=https://github.com/rmorenojr/SimpleAlarmClock
 architectures=avr


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'rtc' in library SimpleAlarmClock is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format